### PR TITLE
Fix: Correct main entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "node-red-contrib",
         "node-red-contrib-ai-agent"
     ],
-    "main": "ai-agent.js",
+    "main": "agent/ai-agent.js",
     "scripts": {
         "test": "mocha \"test/**/*.js\"",
         "update-models": "python scripts/update_models.py"


### PR DESCRIPTION
The 'main' field in package.json was pointing to 'ai-agent.js' in the root directory, but the file is actually located in the 'agent/' folder. This caused MODULE_NOT_FOUND errors when requiring the package.

Fixed by updating 'main' to 'agent/ai-agent.js'.