### PR TITLE
fix: remove stale main field pointing to missing ai-agent.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "node-red-contrib",
         "node-red-contrib-ai-agent"
     ],
-    "main": "ai-agent.js",
     "scripts": {
         "test": "mocha \"test/**/*.js\"",
         "update-models": "python scripts/update_models.py"


### PR DESCRIPTION
Removes the stale `main: "ai-agent.js"` field from package.json since the file doesn't exist in the published npm package (causes ERR_MODULE_NOT_FOUND on root import).

The package uses `node-red.nodes` for Node-RED entry points, which are correct and preserved.

Fixes: lesichkovm/node-red-contrib-ai-agent#5
Related: charles-openclaw/charles-microbounties#676